### PR TITLE
Add CORS support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 const express = require("express");
 const url = require("url");
+const cors = require("cors");
 
 const app = express();
+
+app.use(cors());
 
 app.get("/:delay(\\d+)/:url(*)", function(req, res) {
   const delay = req.params.delay;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "deelay-node",
-  "version": "1.0.0",
+  "name": "deelay",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -165,6 +165,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cors": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
+      "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
+      "requires": {
+        "object-assign": "4.1.1",
+        "vary": "1.1.2"
+      }
     },
     "debug": {
       "version": "2.6.9",
@@ -558,6 +567,11 @@
           }
         }
       }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "on-finished": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "nock": "^9.2.6"
   },
   "dependencies": {
+    "cors": "^2.8.4",
     "express": "^4.16.3"
   }
 }


### PR DESCRIPTION
Cheers for the awesome package!

I needed to simulate certain API requests taking longer than others, in order to guard against race conditions in my app. This package did exactly what I need, except it was missing the `Access-Control-Allow-Origin` header causing my XHR `OPTIONS` requests to fail CORS pre-flight checks.

I've added the `cors` package to allow the express server to accept connections from any host. Please feel free to merge if you think it's useful.