### PR TITLE
Actually using PORT env variable

### DIFF
--- a/bin/deelay.js
+++ b/bin/deelay.js
@@ -4,4 +4,4 @@ const deelay = require('../index.js');
 const http = require('http');
 const port = process.env.PORT || 4567;
 
-http.createServer((req, res) => deelay(req, res, process.stdout)).listen(4567, () => console.log(`Starting delay on port ${port}`));
+http.createServer((req, res) => deelay(req, res, process.stdout)).listen(port, () => console.log(`Starting delay on port ${port}`));


### PR DESCRIPTION
The PORT environment variable was never used before and the port was instead hardcoded to `4567`.